### PR TITLE
feat: add scheduled cache refresh for crypto prices with 429 fallback

### DIFF
--- a/src/main/java/com/proxyapi/cryptomiddleware/CryptoMiddlewareApplication.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/CryptoMiddlewareApplication.java
@@ -2,8 +2,10 @@ package com.proxyapi.cryptomiddleware;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CryptoMiddlewareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/proxyapi/cryptomiddleware/controller/CryptoController.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/controller/CryptoController.java
@@ -1,5 +1,6 @@
 package com.proxyapi.cryptomiddleware.controller;
 
+import com.proxyapi.cryptomiddleware.service.CryptoPriceService;
 import com.proxyapi.cryptomiddleware.service.CryptoService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,14 +12,14 @@ import java.util.Map;
 @RequestMapping("/api/crypto")
 public class CryptoController {
 
-    private final CryptoService cryptoService;
+    private final CryptoPriceService cryptoPriceService;
 
-    public CryptoController(CryptoService cryptoService) {
-        this.cryptoService = cryptoService;
+    public CryptoController(CryptoPriceService cryptoPriceService) {
+        this.cryptoPriceService = cryptoPriceService;
     }
 
     @GetMapping("/prices")
-    public Map<String, Double> getCryptoPrices() {
-        return cryptoService.getPrices();
+    public Map<String, Double> getPrices() {
+        return cryptoPriceService.getPrices();
     }
 }

--- a/src/main/java/com/proxyapi/cryptomiddleware/service/CryptoPriceService.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/service/CryptoPriceService.java
@@ -1,0 +1,61 @@
+package com.proxyapi.cryptomiddleware.service;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Service
+public class CryptoPriceService {
+
+    private final WebClient webClient;
+    private final Map<String, Double> cache = new ConcurrentHashMap<>();
+
+    public CryptoPriceService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.coingecko.com/api/v3")
+                .build();
+    }
+
+    public Map<String, Double> getPrices() {
+        // 👇 si no hay nada en cache, devolvemos vacío en vez de romper
+        return cache.isEmpty() ? Map.of("bitcoin", 0.0, "ethereum", 0.0) : cache;
+    }
+
+    // 👇 este método se ejecuta automáticamente cada 2 minutos
+    @Scheduled(fixedRate = 120000) // 2 minutos
+    public void refreshPrices() {
+        try {
+            Map<String, Map<String, Double>> response =
+                    webClient.get()
+                            .uri(uriBuilder -> uriBuilder
+                                    .path("/simple/price")
+                                    .queryParam("ids", "bitcoin,ethereum")
+                                    .queryParam("vs_currencies", "usd")
+                                    .build())
+                            .retrieve()
+                            .bodyToMono(new ParameterizedTypeReference<Map<String, Map<String, Double>>>() {})
+                            .block();
+
+            if (response != null) {
+                Map<String, Double> newPrices = response.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get("usd")));
+
+                cache.clear();
+                cache.putAll(newPrices);
+
+                System.out.println("Precios actualizados: " + cache);
+            }
+        } catch (WebClientResponseException.TooManyRequests e) {
+            System.out.println("API limit reached (429). Manteniendo datos en cache.");
+        } catch (Exception e) {
+            System.out.println("Error al actualizar precios: " + e.getMessage());
+        }
+    }
+}
+


### PR DESCRIPTION
- Implemented @Scheduled task to refresh Bitcoin and Ethereum prices every 2 minutes
- Added in-memory cache (ConcurrentHashMap) to store last known prices
- Controller now always serves cached data, avoiding API 429 errors
- Added error handling to gracefully fallback when CoinGecko rate limit is reached