### PR TITLE
feat: extend CryptoPriceService to support multiple cryptos and fiat …

### DIFF
--- a/src/main/java/com/proxyapi/cryptomiddleware/config/WebConfig.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.proxyapi.cryptomiddleware.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET");
+    }
+}
+

--- a/src/main/java/com/proxyapi/cryptomiddleware/controller/CryptoController.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/controller/CryptoController.java
@@ -2,8 +2,10 @@ package com.proxyapi.cryptomiddleware.controller;
 
 import com.proxyapi.cryptomiddleware.service.CryptoPriceService;
 import com.proxyapi.cryptomiddleware.service.CryptoService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -18,8 +20,12 @@ public class CryptoController {
         this.cryptoPriceService = cryptoPriceService;
     }
 
-    @GetMapping("/prices")
-    public Map<String, Double> getPrices() {
-        return cryptoPriceService.getPrices();
+    @GetMapping("/price")
+    public ResponseEntity<Map<String, Object>> getCryptoPrices(
+            @RequestParam(defaultValue = "bitcoin") String ids,
+            @RequestParam(defaultValue = "usd") String vsCurrencies) {
+
+        Map<String, Object> response = cryptoPriceService.getPrices(ids, vsCurrencies);
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
…currencies

- Added support for dynamic queries of multiple crypto assets and fiat currencies
- Enriched API response with timestamp, source, and prices
- Implemented cache fallback in case of errors or API rate limiting (429)
- Scheduled automatic refresh for Bitcoin and Ethereum in USD every 2 minutes
- Updated controller to expose /api/crypto/price endpoint with query parameters