### PR TITLE
Refactor CryptoPriceService to support configurable API base URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/proxyapi/cryptomiddleware/service/CryptoPriceService.java
+++ b/src/main/java/com/proxyapi/cryptomiddleware/service/CryptoPriceService.java
@@ -1,5 +1,6 @@
 package com.proxyapi.cryptomiddleware.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -19,9 +20,10 @@ public class CryptoPriceService {
     // Cache: crypto -> { fiat -> price }
     private final Map<String, Map<String, Double>> cache = new ConcurrentHashMap<>();
 
-    public CryptoPriceService(WebClient.Builder webClientBuilder) {
+    public CryptoPriceService(WebClient.Builder webClientBuilder,
+                              @Value("${crypto.api.base-url:https://api.coingecko.com/api/v3}") String baseUrl) {
         this.webClient = webClientBuilder
-                .baseUrl("https://api.coingecko.com/api/v3")
+                .baseUrl(baseUrl)
                 .build();
     }
 

--- a/src/test/java/com/proxyapi/cryptomiddleware/CryptoPriceServiceTest.java
+++ b/src/test/java/com/proxyapi/cryptomiddleware/CryptoPriceServiceTest.java
@@ -1,0 +1,99 @@
+package com.proxyapi.cryptomiddleware;
+
+
+import com.proxyapi.cryptomiddleware.service.CryptoPriceService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CryptoPriceServiceTest {
+
+    private static MockWebServer mockWebServer;
+    private CryptoPriceService cryptoPriceService;
+
+    @BeforeAll
+    static void setupMockServer() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void shutdownMockServer() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void setUp() {
+        WebClient.Builder builder = WebClient.builder();
+        String mockBaseUrl = mockWebServer.url("/").toString();
+        cryptoPriceService = new CryptoPriceService(builder, mockBaseUrl);
+    }
+
+    @Test
+    void refreshPrices_shouldUpdateCacheWithValidResponse() {
+        // given
+        String jsonResponse = "{ \"bitcoin\": { \"usd\": 60000 }, \"ethereum\": { \"usd\": 3000 } }";
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(jsonResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // when
+        cryptoPriceService.refreshPrices();
+        Map<String, Object> response = cryptoPriceService.getPrices("bitcoin,ethereum", "usd");
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Double>> prices = (Map<String, Map<String, Double>>) response.get("prices");
+
+        // then
+        assertThat(prices.get("bitcoin").get("usd")).isEqualTo(60000.0);
+        assertThat(prices.get("ethereum").get("usd")).isEqualTo(3000.0);
+    }
+
+    @Test
+    void refreshPrices_shouldKeepOldCacheOnTooManyRequests() {
+        // given
+        // primera respuesta válida
+        String jsonResponse = "{ \"bitcoin\": { \"usd\": 60000 }, \"ethereum\": { \"usd\": 3000 } }";
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(jsonResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        cryptoPriceService.refreshPrices();
+        Map<String, Object> responseBefore = cryptoPriceService.getPrices("bitcoin,ethereum", "usd");
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Double>> pricesBefore = (Map<String, Map<String, Double>>) responseBefore.get("prices");
+
+        // segunda respuesta simulando 429
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(429));
+
+        // when
+        cryptoPriceService.refreshPrices();
+        Map<String, Object> responseAfter = cryptoPriceService.getPrices("bitcoin,ethereum", "usd");
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Double>> pricesAfter = (Map<String, Map<String, Double>>) responseAfter.get("prices");
+
+        // then
+        assertThat(pricesAfter).isEqualTo(pricesBefore);
+    }
+
+    @Test
+    void getPrices_shouldReturnFallbackWhenCacheEmpty() {
+        // when
+        Map<String, Object> response = cryptoPriceService.getPrices("bitcoin,ethereum", "usd");
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Double>> prices = (Map<String, Map<String, Double>>) response.get("prices");
+
+        // then
+        assertThat(prices).isNotNull();
+        assertThat(prices).isEmpty();
+    }
+}
+


### PR DESCRIPTION
- Removed hardcoded CoinGecko URL from CryptoPriceService
- Added constructor parameter with @Value injection for crypto.api.base-url
- Default base URL remains https://api.coingecko.com/api/v3
- Updated tests to inject MockWebServer base URL instead of hitting real API
- Ensures unit tests run deterministically without depending on live data